### PR TITLE
Fix: windows compilation

### DIFF
--- a/include/R-Engine/Core/Filepath.hpp
+++ b/include/R-Engine/Core/Filepath.hpp
@@ -9,7 +9,7 @@ namespace path {
 /**
 * @brief check if a file exists at the given path
 */
-static constexpr inline bool exists(const std::string &path)
+static inline bool exists(const std::string &path)
 {
     return std::filesystem::exists(path);
 }
@@ -17,7 +17,7 @@ static constexpr inline bool exists(const std::string &path)
 /**
 * @brief get the absolute path from a relative path
 */
-static constexpr inline const std::string get(const std::string &path)
+static inline const std::string get(const std::string &path)
 {
     const auto absolute = std::filesystem::absolute(path);
 

--- a/include/R-Engine/Core/Inline/Logger.inl
+++ b/include/R-Engine/Core/Inline/Logger.inl
@@ -11,7 +11,7 @@
 * public
 */
 
-constexpr void r::Logger::debug([[maybe_unused]] const std::string_view message, [[maybe_unused]] const std::string_view file,
+inline void r::Logger::debug([[maybe_unused]] const std::string_view message, [[maybe_unused]] const std::string_view file,
     [[maybe_unused]] int line) noexcept
 {
 #if defined(ENGINE_DEBUG)
@@ -19,17 +19,17 @@ constexpr void r::Logger::debug([[maybe_unused]] const std::string_view message,
 #endif
 }
 
-constexpr void r::Logger::info(const std::string_view message, const std::string_view file, int line) noexcept
+inline void r::Logger::info(const std::string_view message, const std::string_view file, int line) noexcept
 {
     _emit(message, Level::Info, file, line);
 }
 
-constexpr void r::Logger::warn(const std::string_view message, const std::string_view file, int line) noexcept
+inline void r::Logger::warn(const std::string_view message, const std::string_view file, int line) noexcept
 {
     _emit(message, Level::Warn, file, line);
 }
 
-constexpr void r::Logger::error(const std::string_view message, const std::string_view file, int line) noexcept
+inline void r::Logger::error(const std::string_view message, const std::string_view file, int line) noexcept
 {
     _emit(message, Level::Error, file, line);
 }
@@ -38,7 +38,7 @@ constexpr void r::Logger::error(const std::string_view message, const std::strin
 * private
 */
 
-constexpr void r::Logger::_emit(const std::string_view message, Level level, const std::string_view file, int line) noexcept
+inline void r::Logger::_emit(const std::string_view message, Level level, const std::string_view file, int line) noexcept
 {
     const core::TimePoint now = core::SystemClock::now();
     const std::time_t t = std::chrono::system_clock::to_time_t(now);

--- a/include/R-Engine/Core/Logger.hpp
+++ b/include/R-Engine/Core/Logger.hpp
@@ -9,16 +9,16 @@ class R_ENGINE_API Logger
     public:
         enum class Level { Debug, Info, Warn, Error };
 
-        static constexpr void debug(const std::string_view message, const std::string_view file = __builtin_FILE(),
+        static void debug(const std::string_view message, const std::string_view file = __builtin_FILE(),
             int line = __builtin_LINE()) noexcept;
 
-        static constexpr void info(const std::string_view message, const std::string_view file = __builtin_FILE(),
+        static void info(const std::string_view message, const std::string_view file = __builtin_FILE(),
             int line = __builtin_LINE()) noexcept;
 
-        static constexpr void warn(const std::string_view message, const std::string_view file = __builtin_FILE(),
+        static void warn(const std::string_view message, const std::string_view file = __builtin_FILE(),
             int line = __builtin_LINE()) noexcept;
 
-        static constexpr void error(const std::string_view message, const std::string_view file = __builtin_FILE(),
+        static void error(const std::string_view message, const std::string_view file = __builtin_FILE(),
             int line = __builtin_LINE()) noexcept;
 
     private:
@@ -33,7 +33,7 @@ class R_ENGINE_API Logger
         static constexpr std::string_view _level_to_string(Level lvl) noexcept;
         static constexpr std::string_view _level_to_color(Level lvl) noexcept;
 
-        static constexpr void _emit(const std::string_view message, Level level, const std::string_view file, int line) noexcept;
+        static void _emit(const std::string_view message, Level level, const std::string_view file, int line) noexcept;
 };
 
 }// namespace r

--- a/include/R-Engine/ECS/Inline/Storage.inl
+++ b/include/R-Engine/ECS/Inline/Storage.inl
@@ -35,7 +35,7 @@ void r::ecs::Column<T>::move_to(usize index, IColumn &dest)
 }
 
 template<typename T>
-std::unique_ptr<r::ecs::IColumn> r::ecs::Column<T>::clone_empty() const
+std::shared_ptr<r::ecs::IColumn> r::ecs::Column<T>::clone_empty() const
 {
-    return std::make_unique<Column<T>>();
+    return std::make_shared<Column<T>>();
 }

--- a/include/R-Engine/ECS/Storage.hpp
+++ b/include/R-Engine/ECS/Storage.hpp
@@ -70,9 +70,9 @@ struct R_ENGINE_API IColumn {
 
         /**
          * @brief Creates a new, empty column of the same underlying type.
-         * @return A unique_ptr to the new IColumn.
+         * @return A shared_ptr to the new IColumn.
          */
-        virtual std::unique_ptr<IColumn> clone_empty() const = 0;
+        virtual std::shared_ptr<IColumn> clone_empty() const = 0;
 };
 
 /**
@@ -87,7 +87,7 @@ struct Column : IColumn {
         void remove_swap_back(usize index) override;
         void *get_ptr(usize index) override;
         void move_to(usize index, IColumn &dest) override;
-        std::unique_ptr<IColumn> clone_empty() const override;
+        std::shared_ptr<IColumn> clone_empty() const override;
 };
 
 /**
@@ -96,7 +96,7 @@ struct Column : IColumn {
  */
 struct R_ENGINE_API Table {
         std::vector<Entity> entities;
-        std::vector<std::unique_ptr<IColumn>> columns;
+        std::vector<std::shared_ptr<IColumn>> columns;
 
         /**
          * @brief Adds an entity to the table.

--- a/include/R-Engine/Maths/Inline/Vec.inl
+++ b/include/R-Engine/Maths/Inline/Vec.inl
@@ -242,7 +242,7 @@ template<usize N, typename T>
     requires concepts::Vec<N, T>
 constexpr Vec<N, T> Vec<N, T>::cross(const Vec<N, T> &other) const noexcept
 {
-    if (N != 3) {
+    if constexpr (N != 3) {
         return Vec<N, T>{0};
     }
 


### PR DESCRIPTION
This PR implements the following changes to ensure MSVC compilation:

Removing `constexpr` on [Logger](https://github.com/Leorevoir/R-Engine/compare/fix/windows_compilation?expand=1#diff-212ee022abe705dc9edd3e4b4fa869640e1d5ee14beb49a521a213cd1c821ea1) and [Filepath](https://github.com/Leorevoir/R-Engine/compare/fix/windows_compilation?expand=1#diff-481579e48541541ab745f3a98e24389b37cb1940155d57cd99d3cf49743b3c79), as they depend on functions from `std::filesystem` and `std::clock` that are non `constexpr`.

MSVC found that some elements of `columns` may be copied (and hence would call the deleted copy constructor from `std::unique_ptr`. `columns` was thus transformed to a `std::shared_ptr` to allow this behavior.

Finally, in [Vec.inl](https://github.com/Leorevoir/R-Engine/compare/fix/windows_compilation?expand=1#diff-df3c967b0b34f0015867c66378f7fb7474bc654906388ff8e58fc1cc048a269e), line 245, the condition can be made constexpr, and MSVC insisted on it.